### PR TITLE
fix: Ensure verifyKvStoreConnection takes into account rootPrefix

### DIFF
--- a/src/main/java/com/ibm/watson/etcd/EtcdUtilsFactory.java
+++ b/src/main/java/com/ibm/watson/etcd/EtcdUtilsFactory.java
@@ -154,7 +154,7 @@ public class EtcdUtilsFactory extends KVUtilsFactory {
             path += "/";
         }
         ByteString bs = ByteString.copyFromUtf8(path);
-        return rootPrefix != null? rootPrefix.concat(bs) : bs;
+        return rootPrefix != null ? rootPrefix.concat(bs) : bs;
     }
 
     @Override
@@ -162,12 +162,11 @@ public class EtcdUtilsFactory extends KVUtilsFactory {
         return ETCD_TYPE;
     }
 
-    private static final ByteString TEST_KEY =
-            ByteString.copyFromUtf8("__DUMMY_KEY_FOR_TESTING_CONNECTION");
+    private static final String TEST_PATH = "/__DUMMY_KEY_FOR_TESTING_CONNECTION";
 
     @Override
     public ListenableFuture<Boolean> verifyKvStoreConnection() {
-        return Futures.catching(Futures.transform(client.getKvClient().get(TEST_KEY).countOnly()
+        return Futures.catching(Futures.transform(client.getKvClient().get(pathToKey(TEST_PATH, false)).countOnly()
                         .serializable(true).async(), rr -> Boolean.TRUE, MoreExecutors.directExecutor()),
                 Exception.class, e -> { // Intentionally not catching Errors
                     throw new RuntimeException("etcd connection verification failed", e);
@@ -209,7 +208,7 @@ public class EtcdUtilsFactory extends KVUtilsFactory {
             return newValue;
         }
         RangeResponse rr = resp.getResponses(0).getResponseRange();
-        return rr.getKvsCount() == 0? null : rr.getKvs(0).getValue().toByteArray();
+        return rr.getKvsCount() == 0 ? null : rr.getKvs(0).getValue().toByteArray();
     }
 
     public EtcdClient getClient() {


### PR DESCRIPTION
#### Motivation

Instances of `KVUtilsFactory` are initialized for a particular connection configuration, which for etcd includes a "chroot" `rootPrefix`. All the utility methods honor this prefix, except the `verifyKvConnection` method.

This can cause problems when role-based access controls are configured in etcd and the client-configured userid doesn't have access outside of the `rootPrefix` key range. In this case the `verifyKvConnection` call will fail unexpectedly with a permission denied error.

#### Modifications

- Adjust the `verifyKvConnection` to perform a get on a dummy (likely nonexistent) key within the `rootPrefix` range
- Add auth-based unit test

#### Result

`KVUtilsFactory#verifyKvConnection` will work as expected in key-specific auth cases.